### PR TITLE
Update Remote.cs to add UnregisterKnownKind

### DIFF
--- a/src/Proto.Remote/Remote.cs
+++ b/src/Proto.Remote/Remote.cs
@@ -4,6 +4,16 @@
 //   </copyright>
 // -----------------------------------------------------------------------
 // Modified file in context of repo fork : https://github.com/Optis-World/protoactor-dotnet
+// Copyright 2019 ANSYS, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 using System;
 using System.Collections.Generic;

--- a/src/Proto.Remote/Remote.cs
+++ b/src/Proto.Remote/Remote.cs
@@ -3,6 +3,7 @@
 //       Copyright (C) 2015-2018 Asynkron HB All rights reserved
 //   </copyright>
 // -----------------------------------------------------------------------
+// Modified file in context of repo fork : https://github.com/Optis-World/protoactor-dotnet
 
 using System;
 using System.Collections.Generic;
@@ -34,6 +35,12 @@ namespace Proto.Remote
             Kinds.Add(kind, props);
         }
 
+        // Modified class in context of repo fork : https://github.com/Optis-World/protoactor-dotnet
+        public static void UnregisterKnownKind(string kind)
+        {
+            Kinds.Remove(kind);
+        }
+        
         public static Props GetKnownKind(string kind)
         {
             if (Kinds.TryGetValue(kind, out var props)){


### PR DESCRIPTION
Allow to unregister known kind in order to be able to reload/reuse a remote config under the same process runtime.